### PR TITLE
Follow relative-path redirects correctly in `werkzeug.test.Client`.

### DIFF
--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -42,6 +42,7 @@ from .urls import _urlencode
 from .urls import iri_to_uri
 from .utils import cached_property
 from .utils import get_content_type
+from .utils import resolve_location
 from .wrappers.request import Request
 from .wrappers.response import Response
 from .wsgi import ClosingIterator
@@ -1081,9 +1082,12 @@ class Client:
 
         :meta private:
         """
-        scheme, netloc, path, qs, anchor = urlsplit(response.location)
+        request_environ = response.request.environ
+        absolute_location = resolve_location(request_environ, response.location)
+
+        scheme, netloc, path, qs, anchor = urlsplit(absolute_location)
         builder = EnvironBuilder.from_environ(
-            response.request.environ, path=path, query_string=qs
+            request_environ, path=path, query_string=qs
         )
 
         to_name_parts = netloc.split(":", 1)[0].split(".")

--- a/src/werkzeug/utils.py
+++ b/src/werkzeug/utils.py
@@ -11,6 +11,7 @@ import unicodedata
 from datetime import datetime
 from time import time
 from urllib.parse import quote
+from urllib.parse import urljoin
 from zlib import adler32
 
 from markupsafe import escape
@@ -22,6 +23,8 @@ from .datastructures import Headers
 from .exceptions import NotFound
 from .exceptions import RequestedRangeNotSatisfiable
 from .security import safe_join
+from .urls import iri_to_uri
+from .wsgi import get_current_url
 from .wsgi import wrap_file
 
 if t.TYPE_CHECKING:
@@ -688,3 +691,9 @@ class ImportStringError(ImportError):
 
     def __repr__(self) -> str:
         return f"<{type(self).__name__}({self.import_name!r}, {self.exception!r})>"
+
+
+def resolve_location(environ: WSGIEnvironment, location: str) -> str:
+    current_url = get_current_url(environ, strip_querystring=True)
+    current_url = iri_to_uri(current_url)
+    return urljoin(current_url, location)

--- a/src/werkzeug/wrappers/response.py
+++ b/src/werkzeug/wrappers/response.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import typing as t
 from http import HTTPStatus
-from urllib.parse import urljoin
 
 from ..datastructures import Headers
 from ..http import remove_entity_headers
@@ -11,8 +10,8 @@ from ..sansio.response import Response as _SansIOResponse
 from ..urls import _invalid_iri_to_uri
 from ..urls import iri_to_uri
 from ..utils import cached_property
+from ..utils import resolve_location
 from ..wsgi import ClosingIterator
-from ..wsgi import get_current_url
 from werkzeug._internal import _get_environ
 from werkzeug.http import generate_etag
 from werkzeug.http import http_date
@@ -484,9 +483,7 @@ class Response(_SansIOResponse):
 
             if self.autocorrect_location_header:
                 # Make the location header an absolute URL.
-                current_url = get_current_url(environ, strip_querystring=True)
-                current_url = iri_to_uri(current_url)
-                location = urljoin(current_url, location)
+                location = resolve_location(environ, location)
 
             headers["Location"] = location
 


### PR DESCRIPTION
When using the `follow_redirects` feature of `werkzeug.test.Client.open()`, redirects for relative paths are not followed correctly. All relative paths are resolved as though they start with `/`, even when they don't.

This issue has become more noticeable since `2.1.0`, when `Response.autocorrect_location_header` was [switched to default-false](https://github.com/pallets/werkzeug/issues/2352), because `Location` headers are no longer automatically resolved to absolute URLs on the server side by default (one must now opt-in to that behavior).

To bring `test.Client` in line with real clients, let's resolve the target `response.location` to an absolute URL before following it.

TODO: Port this fix to latest `werkzeug` (currently `3.0.3`) when we upgrade.

## Testing
- Updated unit tests.
- `tox` passes locally (skipped for 2 envs i dont have installed):
  ```
  $ tox
  ...
    py312: OK (14.59=setup[0.77]+cmd[13.81] seconds)
    py311: OK (12.68=setup[0.55]+cmd[12.14] seconds)
    py310: OK (13.51=setup[0.51]+cmd[13.00] seconds)
    py39: OK (13.05=setup[0.51]+cmd[12.54] seconds)
    py38: SKIP (0.01 seconds)
    pypy310: SKIP (0.01 seconds)
    style: OK (2.66=setup[0.00]+cmd[2.66] seconds)
    typing: OK (0.72=setup[0.47]+cmd[0.26] seconds)
    docs: OK (7.85=setup[0.49]+cmd[7.37] seconds)
    congratulations :) (65.15 seconds)
  ```
  - (I haven't figured out how to get GitHub actions to build it for the PR yet.)